### PR TITLE
Fix bar coordinates check for mouse warp

### DIFF
--- a/lib/warp.c
+++ b/lib/warp.c
@@ -88,9 +88,9 @@ warp(const Client *c)
 	/* Do not warp if cursor rests on one of the bars */
 	for (m = mons; m; m = m->next)
 		for (bar = m->bar; bar; bar = bar->next)
-			if (x > bar->bx &&
+			if (x >= bar->bx &&
 				x < bar->bx + bar->bw &&
-				y > bar->by &&
+				y >= bar->by &&
 				y < bar->by + bar->bh)
 				return;
 


### PR DESCRIPTION
I often find myself switching workspaces with my mouse and I noticed that if my cursor was at the screen's edges the mouse Warp functionality would still trigger.

This PR fixes the check done by Warp that was 1 pixel short.